### PR TITLE
Another Gemfile modification 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'soomo-mbus-configuration', :github => 'soomo/soomo-mbus-configuration', :branch => 'master'
+gem 'soomo-mbus-configuration', :git => 'git@github.com:soomo/soomo-mbus-configuration.git'


### PR DESCRIPTION
@matthewbennink I ran into an bundle error trying to install gems for this repo yet again. Noticed from the Bundler docs that the `:github` key is for public repos only. Was able to install required gems without an issue with this modification. 